### PR TITLE
Sk canvas init

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -136,15 +136,17 @@ function App() {
         <Router>
           <NavBar user={users} />
           <Switch>
+            {/* why twice? */}
             <Route exact path="/" component={Splash} />
+
+            <Route exact path="/">
+              <Splash />
+            </Route>
 
             <Route exact path="/login">
               <Login handleSubmit={handleSubmit} handleInputChange={handleInputChange}
                 // switch={signUpBtn} formMsg={formMsg.Msg} formBtn={hapticBtn.Btn} 
                 isLoggedIn={users.isLoggedIn} />
-            </Route>
-            <Route exact path="/">
-              <Splash />
             </Route>
 
             <Route exact path="/dashboard">

--- a/src/components/MapCanvas/index.js
+++ b/src/components/MapCanvas/index.js
@@ -568,9 +568,7 @@ export default function InfiniteCanvas(props) {
         idx: idx,
         type: activePin,
         x: e.evt.clientX - stagePosition.x,
-        y: e.evt.clientY - stagePosition.y - 30,
-        // x: e.evt.clientX - stagePosition.x - 5,
-        // y: e.evt.clientY - stagePosition.y - grid.tileSize * 2,
+        y: e.evt.clientY - stagePosition.y - grid.tileSize,
         fill: pinColors[activePin],
         data: null,
       }
@@ -856,6 +854,18 @@ export default function InfiniteCanvas(props) {
     
   }
 
+  const handlePinDragStart = (e) => {
+    setActivePin(null);
+    setShadowPinParams({
+      ...shadowPinParams,
+      display: 'none',
+      top: -500,
+      left: -500,
+      opacity: 0
+    })
+    setDraggingPin({x: e.target.x(), y: e.target.y()});
+  }
+
   const handlePinDragEnd = (e) => {
     const idx = e.target.id();
 
@@ -1058,7 +1068,7 @@ export default function InfiniteCanvas(props) {
                   data="M0,27 Q0,28 10,15 A15,15 0,1,0 -10,15 Q0,28 0,27" 
                   visible={pinsVisible}
                   onClick={(e) => handlePinOnClick(e)}
-                  onDragStart={(e) => setDraggingPin({x: e.target.x(), y: e.target.y()})}
+                  onDragStart={(e) => handlePinDragStart(e)}
                   onDragEnd={(e) => handlePinDragEnd(e)}
                   onMouseEnter={(e) => handleMouseEnter(e, 'pin', 'pointer')}
                   onMouseLeave={handleMouseLeave}

--- a/src/components/MapControls/functions.js
+++ b/src/components/MapControls/functions.js
@@ -124,3 +124,34 @@ const createMapTiles = (mapId) => {
   }
   return mapTiles;
 }
+
+/**
+   * DATE FUNCTION
+   */
+ const handleDateTime = (get='time') => {
+  const dt = new Date();
+  let month = (dt.getMonth() + 1);
+  let date = dt.getDate();
+  let hours = dt.getHours();
+  let minutes = dt.getMinutes();
+  let seconds = dt.getSeconds();
+
+  if(month < 10) { month = `0${month}` };
+  if(date < 10) { date = `0${date}`};
+  if(hours < 10) { hours = `0${hours}`};
+  if(minutes < 10) { minutes = `0${minutes}`};
+  if(seconds < 10) { seconds = `0${seconds}`};
+
+  let today = dt.getFullYear() +'-'+ month +'-'+ date;
+  let timestamp = hours +':'+ minutes +':'+ seconds;
+
+  if(get === 'time') {
+    return timestamp;
+  } else if(get === 'date') {
+    return today;
+  } else if(get === 'datetime' || get === 'both') {
+    return `${today}T${timestamp}`;
+  }
+
+  return null;
+}

--- a/src/components/MapControls/index.js
+++ b/src/components/MapControls/index.js
@@ -278,6 +278,8 @@ export default function MapControls({ controlsData }) {
     isDrawerOpened: true
   })
 
+  // console.log("map controls controlsData", controlsData);
+
   const theme = useTheme();
 
   const handleDrawerOpen = () => {
@@ -315,12 +317,12 @@ export default function MapControls({ controlsData }) {
    */
 
   // pins
-  useHotkeys('ctrl+1, command+1', (e) => controlsData.pinKeyboardShortcuts(e, controlsData.pins.activePin !== 'type1' ? 'type1' : null));
-  useHotkeys('ctrl+2, command+2', (e) => controlsData.pinKeyboardShortcuts(e, controlsData.pins.activePin !== 'type2' ? 'type2' : null));
-  useHotkeys('ctrl+3, command+3', (e) => controlsData.pinKeyboardShortcuts(e, controlsData.pins.activePin !== 'type3' ? 'type3' : null));
-  useHotkeys('ctrl+4, command+4', (e) => controlsData.pinKeyboardShortcuts(e, controlsData.pins.activePin !== 'type4' ? 'type4' : null));
-  useHotkeys('ctrl+5, command+5', (e) => controlsData.pinKeyboardShortcuts(e, controlsData.pins.activePin !== 'type5' ? 'type5' : null));
-  useHotkeys('esc', (e) => controlsData.pinKeyboardShortcuts(e, null) );
+  useHotkeys('ctrl+1, command+1', (e) => controlsData.pinKeyboardShortcuts(e));
+  useHotkeys('ctrl+2, command+2', (e) => controlsData.pinKeyboardShortcuts(e));
+  useHotkeys('ctrl+3, command+3', (e) => controlsData.pinKeyboardShortcuts(e));
+  useHotkeys('ctrl+4, command+4', (e) => controlsData.pinKeyboardShortcuts(e));
+  useHotkeys('ctrl+5, command+5', (e) => controlsData.pinKeyboardShortcuts(e));
+  useHotkeys('esc', (e) => controlsData.pinKeyboardShortcuts(e) );
 
   return (
     <Box>

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -24,12 +24,12 @@ const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
     justifyContent: 'space-between',
-    position: 'sticky',
+    position: 'relative',
     top: 0,
     zIndex: 9999,
     width: '90%',
     margin: '0 auto',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   title: {
     cursor: 'pointer',
@@ -38,7 +38,8 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
     height: '75px',
-    position: 'absolute'
+    // position: 'absolute',
+
   },
   navLink: {
     textDecoration: 'none',

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between',
     position: 'sticky',
     top: 0,
-    zIndex: 10,
+    zIndex: 9999,
     width: '90%',
     margin: '0 auto',
     alignItems: 'center'
@@ -37,7 +37,8 @@ const useStyles = makeStyles((theme) => ({
   navBar: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
-    height: '75px'
+    height: '75px',
+    position: 'absolute'
   },
   navLink: {
     textDecoration: 'none',

--- a/src/components/SliderDrawer/index.js
+++ b/src/components/SliderDrawer/index.js
@@ -154,9 +154,21 @@ export default function SliderDrawer({ handleMapData, handleDraggableItem }) {
 
   const handleChangeTileSet = (event) => {
     setTileSetState(event.target.value);
+    localStorage.setItem('dungen_tileset', event.target.value);
   };
 
   const { isDrawerOpened } = state;
+
+  useEffect(() => {
+    // FETCH ALL TileSets
+    API.getTileSets().then(tileSets => {
+      setTileSetListState(tileSets.data)
+    }).catch(err => console.error(err))
+
+    if(localStorage.getItem('dungen_tileset') !== undefined) {
+      setTileSetState(localStorage.getItem('dungen_tileset'));
+    }
+  }, []);
 
   useEffect(() => {
     // GET ALL TILES FROM ONE TileSets, RERUN WHEN TileSets IS CHANGED
@@ -178,13 +190,6 @@ export default function SliderDrawer({ handleMapData, handleDraggableItem }) {
       })
       .catch(err => console.error(err))
   }, [tileSetState]);
-
-  useEffect(() => {
-    // FETCH ALL TileSets
-    API.getTileSets().then(tileSets => {
-      setTileSetListState(tileSets.data)
-    }).catch(err => console.error(err))
-  }, []);
 
   const capitalizeMe = (name) => {
     return name.charAt(0).toUpperCase() + name.slice(1);
@@ -209,7 +214,7 @@ export default function SliderDrawer({ handleMapData, handleDraggableItem }) {
       >
         {/*==================== Calvin's doing something wierd ===================*/}
         
-        {/* <StartMap handleMapData={handleMapData} /> */}
+        <StartMap handleMapData={handleMapData} />
         
         {/*==================== Calvin's done doing something wierd ===================*/}
         <Container className={classes.drawerHeader}>

--- a/src/components/SliderDrawer/index.js
+++ b/src/components/SliderDrawer/index.js
@@ -209,7 +209,7 @@ export default function SliderDrawer({ handleMapData, handleDraggableItem }) {
       >
         {/*==================== Calvin's doing something wierd ===================*/}
         
-        <StartMap handleMapData={handleMapData} />
+        {/* <StartMap handleMapData={handleMapData} /> */}
         
         {/*==================== Calvin's done doing something wierd ===================*/}
         <Container className={classes.drawerHeader}>

--- a/src/components/StartMap/index.js
+++ b/src/components/StartMap/index.js
@@ -36,16 +36,24 @@ function StartMap(props) {
         name: savedMap !== null ? savedMap.name : "",
         environment: savedMap !== null ? savedMap.environment : '1',
         infinite: savedMap !== null ? savedMap.infinite : true,
-        rows: savedMap !== null ? savedMap.rows : null,
-        columns: savedMap !== null ? savedMap.columns : null,
+        rows: savedMap !== null ? parseInt(savedMap.rows) : 1,
+        columns: savedMap !== null ? parseInt(savedMap.columns) : 1,
         public: savedMap !== null ? savedMap.public : true
     });
+
+    useEffect(() => {
+        if(savedMap === null) {
+            localStorage.setItem( 'dungen_map', JSON.stringify(newMap) )
+        } else {
+            localStorage.setItem( 'dungen_map', JSON.stringify({...savedMap, ...newMap}) )
+        }
+    }, [newMap]);
 
     const handleInputChange = event => {
         const { name, value } = event.target;
         setMapState({
             ...newMap,
-            [name]: value
+            [name]: name === 'rows' || name === 'columns' ? parseInt(value) : value
         })
     }
 
@@ -55,15 +63,11 @@ function StartMap(props) {
             console.log("trying to to save a map");
 
         }).catch(err => console.error(err))
-
-        localStorage.setItem('dungen_map', JSON.stringify({...savedMap, ...newMap}))
-
         props.handleMapData(newMap)
     }
 
     const handleCheck = event => {
-        setMapState({ ...newMap, [event.target.name]: event.target.checked, rows: !newMap.infinite ? null : newMap.rows, columns: !newMap.infinite ? null : newMap.columns });
-        // setMapState({...newMap, row: null, column: null})
+        setMapState({ ...newMap, [event.target.name]: event.target.checked, rows: !newMap.infinite ? 1 : parseInt(newMap.rows), columns: !newMap.infinite ? 1 : parseInt(newMap.columns) });
     };
 
     const [environmentState, setEnvironmentState] = useState(null)

--- a/src/pages/MapBuilder/index.js
+++ b/src/pages/MapBuilder/index.js
@@ -146,7 +146,7 @@ export default function MapBuilder(props) {
   const [mapTitle, setMapTitle] = useState("Untitled Map");
 
   // map builder init data for new maps
-  const [newMapData, setNewMapData] = useState(null);
+  const [mapData, setMapData] = useState(null);
 
   // FOR SNACKBAR NOTIFICATION!
   const [saved, setSavedState] = useState(false);
@@ -168,6 +168,23 @@ export default function MapBuilder(props) {
   const savedMap = localStorage.getItem('dungen_map') !== undefined ? JSON.parse(localStorage.getItem('dungen_map')) : null;
 
   useEffect(() => {
+    if(savedMap === null) {
+      const starterMapData = {
+        name: "",
+        rows: 10,
+        columns: 10,
+        tileSize: 100,
+        infinite: true,
+        environment: 1,
+        layout: [], 
+        pins: [], 
+        pinsVisible: true, 
+        public: false,
+        userId: null
+      }
+      localStorage.setItem('dungen_map', JSON.stringify(starterMapData));
+    }
+
     if (id !== undefined) {
       API.getSingleMap(id)
         .then((res) => {
@@ -216,10 +233,9 @@ export default function MapBuilder(props) {
   };
 
   const handleStartMapFormSubmit = (mapData) => {
-    console.log("pMB347", mapData);
     if(mapData.name !== "") { setMapTitle(mapData.name); }
-    setNewMapData(mapData);
-    console.log(mapData);
+
+    setMapData(mapData);
   }
 
   const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
@@ -229,7 +245,7 @@ export default function MapBuilder(props) {
   return !isMobile ? (
     <Box>
       {/* MAP TITLE */}
-      <Container className={classes.titleWrapper}>
+      {/* <Container className={classes.titleWrapper}>
         <Typography variant="h2" className={classes.title}>
           {mapTitle}
         </Typography>
@@ -252,14 +268,14 @@ export default function MapBuilder(props) {
             />
           </form>
         )}
-      </Container>
+      </Container> */}
 
       {/* MAP BUILDER */}
       <MapCanvas
         loadThisMap={id}
         toggleSavedState={toggleSavedState}
         toggleAuthState={toggleAuthState}
-        init={newMapData}
+        init={mapData}
       />
 
       <SliderDrawer handleDraggableItem={handleDraggableItem} handleMapData={handleStartMapFormSubmit} />

--- a/src/pages/RenderedMap/index.js
+++ b/src/pages/RenderedMap/index.js
@@ -151,7 +151,7 @@ export default function RenderedMap(props) {
   }
 
   return (
-    <Container style={{paddingTop: 85}}>
+    <Container>
       <Typography variant='h2' className={classes.title} ref={mapTitleRef}>
         {mapTitleRef.current}
       </Typography>

--- a/src/pages/RenderedMap/index.js
+++ b/src/pages/RenderedMap/index.js
@@ -151,7 +151,7 @@ export default function RenderedMap(props) {
   }
 
   return (
-    <Container>
+    <Container style={{paddingTop: 85}}>
       <Typography variant='h2' className={classes.title} ref={mapTitleRef}>
         {mapTitleRef.current}
       </Typography>


### PR DESCRIPTION
- dragging tile onto canvas now shows "shadow tile" and checks for intersections with already placed tiles
- changing environment changes bg color of map
- can switch between infinite/finite grid
- can change number of rows/columns visible on grid (doesn't [yet] affect tile placement)
- pin selection / deselection hotkeys configured & working
- shadow tile, shadow pin, and context menu hidden when dragging onto canvas / dragging tile